### PR TITLE
Fix repo-type in w3c.json file

### DIFF
--- a/w3c.json
+++ b/w3c.json
@@ -1,5 +1,5 @@
  {
     "group":      [154550]
 ,   "contacts":   ["simoneonofri"]
-,   "repo-type":  "rec-track"
+,   "repo-type":  "others"
 }


### PR DESCRIPTION
The repository does not contain any rec-track document. Some tools rely on the information in `w3c.json` for processing. See [The w3c.json file](https://w3c.github.io/w3c.json.html) for details.